### PR TITLE
Fix to issue #16 : Skipping test case if there is no internet connection.

### DIFF
--- a/tests/testthat/test_api_access.R
+++ b/tests/testthat/test_api_access.R
@@ -1,4 +1,9 @@
 test_that("welcome returns correct name", {
+
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
+  testthat::skip_on_cran()
+
   expect_equal(bnm_api("/welcome")$content$name,
                "BNM.API")
 })

--- a/tests/testthat/test_base_rate.R
+++ b/tests/testthat/test_base_rate.R
@@ -1,6 +1,7 @@
 test_that("Test base_rate() for incorrect input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid length of bank_code argument

--- a/tests/testthat/test_consumer_alert.R
+++ b/tests/testthat/test_consumer_alert.R
@@ -1,6 +1,7 @@
 test_that("Test consumer_alert() for incorrect input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for unused argument

--- a/tests/testthat/test_currencies_renminbi.R
+++ b/tests/testthat/test_currencies_renminbi.R
@@ -1,6 +1,7 @@
 test_that("Test renminbi() for incorrect input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid type value

--- a/tests/testthat/test_daily_fx_turnover.R
+++ b/tests/testthat/test_daily_fx_turnover.R
@@ -1,6 +1,7 @@
 test_that("Test daily_fx_turnover() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for unused argument error

--- a/tests/testthat/test_exchange_rate.R
+++ b/tests/testthat/test_exchange_rate.R
@@ -1,6 +1,7 @@
 test_that("Test exchange_rate() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid session number

--- a/tests/testthat/test_interbank_swap.R
+++ b/tests/testthat/test_interbank_swap.R
@@ -1,6 +1,7 @@
 test_that("Test interbank_swap() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid argument

--- a/tests/testthat/test_interest_rate.R
+++ b/tests/testthat/test_interest_rate.R
@@ -1,6 +1,7 @@
 test_that("Test interest_rate() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid date values and types in various combinations

--- a/tests/testthat/test_interest_volume.R
+++ b/tests/testthat/test_interest_volume.R
@@ -1,6 +1,7 @@
 test_that("Test interest_volume() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid date values and types in various combinations

--- a/tests/testthat/test_islamic_interbank_rate.R
+++ b/tests/testthat/test_islamic_interbank_rate.R
@@ -1,6 +1,7 @@
 test_that("Test islamic_interbank_rate() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid date values and types

--- a/tests/testthat/test_kijang_emas.R
+++ b/tests/testthat/test_kijang_emas.R
@@ -1,6 +1,7 @@
 test_that("Test kijang_emas() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid date values and types

--- a/tests/testthat/test_kl_usd_reference_rate.R
+++ b/tests/testthat/test_kl_usd_reference_rate.R
@@ -1,6 +1,7 @@
 test_that("Test kl_usd_reference_rate() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid date values and types

--- a/tests/testthat/test_opr.R
+++ b/tests/testthat/test_opr.R
@@ -1,6 +1,7 @@
 test_that("Test opr() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid years

--- a/tests/testthat/test_usd_interbank_intraday_rate.R
+++ b/tests/testthat/test_usd_interbank_intraday_rate.R
@@ -1,6 +1,7 @@
 test_that("Test usd_interbank_intraday_rate() for wrong input errors", {
 
-  testthat::skip_if_offline()
+  # Skip if no internet connection, or the bnm site is down.
+  testthat::skip_if_offline("api.bnm.gov.my")
   testthat::skip_on_cran()
 
   ## Test for invalid date values and types


### PR DESCRIPTION
As stated in issue #16 , a test case was failing when there is no internet connection.
I added `testthat::skip_if_online` in this test case.
Also, I think, in the rest of the test cases, putting `testthat::skip_if_offline("api.bnm.gov.my")` would be better than `testthat::skip_if_offline()`, as it is also going to check if the BNM API is working or not.

To check this behavior, run `devtools::test()` with and without internet connection.